### PR TITLE
Fix alignment warning in gdt_install

### DIFF
--- a/gdt.c
+++ b/gdt.c
@@ -56,5 +56,5 @@ void gdt_install(void)
     gdt_set_gate(1, 0, 0xFFFFFFFF, 0x9A, 0xCF); /* Code segment */
     gdt_set_gate(2, 0, 0xFFFFFFFF, 0x92, 0xCF); /* Data segment */
 
-    load_gdt((unsigned int *)&gp);
+    load_gdt(&gp);  // Changed from: load_gdt((unsigned int *)&gp);
 }


### PR DESCRIPTION
#2 
Remove unnecessary cast when calling load_gdt to fix compiler warning: 'converting a packed struct gdt_ptr pointer to a unsigned int pointer may result in an unaligned pointer value'

Changed load_gdt((unsigned int *)&gp) to load_gdt(&gp) since the function accepts void* and implicit conversion is safe.